### PR TITLE
Revert "Update abc.sh"

### DIFF
--- a/oozie1/abc.sh
+++ b/oozie1/abc.sh
@@ -7,8 +7,6 @@ head -n 260 /usr/hdp/2.2.4.2-2/hadoop/conf/yarn-site.xml | tail -n 2
 hive-site.xml
 /usr/hdp/2.2.4.2-2/hive/conf/hive-site.xml
 
-#new changes made which will ruin production
-
 
 
 


### PR DESCRIPTION
this is changed because this commit isnt safe for prod.

This reverts commit f13ac32c7937f10fa6c727f7350a9efa045dc793.